### PR TITLE
Tested Trezor One on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tested with these devices on macOS, Linux, and Windows:
 | Hypersecu | HyperFIDO U2F Security Key | 0x096e | 0x0880 | 10.05 | Yes | Also known as Feitian FIDO K5. |
 | NEOWAVE | Keydo | 0x1e0d | 0xf1d0 | 1.00 | Yes | |
 | Plug-up | Security Key | 0x2581 | 0xf1d0 | 0.01 | No | |
+| SatoshiLabs | Bitcoin Wallet [TREZOR] | 0x534c | 0x0001 | 1.6.0 | ? | Tested on Linux |
 | SecureMetric | IDENOS | 0x096e | 0x0850 | 10.05 | Yes | Also known as Feitian FIDO K4. |
 | Yubico | FIDO U2F Security Key | 0x1050 | 0x0120 | 3.33 | No | White LED-backlit key icon on button. |
 | Yubico | Special Edition Octocat Security Key | 0x1050 | 0x0120 | 4.18 | Yes | Green LED-backlit "y" icon on button, GitHub Octocat logo on the back. |


### PR DESCRIPTION
It works also on "Trezor One". And I use U2F of Trezor One for 2FA authentication on my desktop.
```
~/go/src/github.com/xaionaro-go/u2f/u2ftoken/example$ go run main.go 
2018/06/13 21:47:02 manufacturer = "SatoshiLabs", product = "SatoshiLabs TREZOR", vid = 0x0001, pid = 0x534c
2018/06/13 21:47:02 version: U2F_V2
2018/06/13 21:47:02 registering, provide user presence
2018/06/13 21:47:05 registered: 05045d67a72e4c8cb9024d6f36a13f24c12dda1b48ba271eec362a52c4f0e241117eaa98101983d49c74e52d7fbd205c5018721fec70f425579f9d77529785595fe040a36ed1dd35d324aaa22c71f29ca04682f15bb4c11d5b43f738928fdc154c93d5cca8cdb98c49d4d917f8e5a4a779d251bd92275802959a0b4f4369c9f6e6b128308201183081c0020900b1d98f426472d32c300a06082a8648ce3d04030230153113301106035504030c0a5472657a6f7220553246301e170d3136303432393133333135335a170d3236303432373133333135335a30153113301106035504030c0a5472657a6f72205532463059301306072a8648ce3d020106082a8648ce3d03010703420004d918bdfa8a54ac92e90da91fca7aa26454c0d17336314dde83a54b86b5df4ef052659a1d6ffcb7467f1acddb8a33080b5eed918913f443a5261bc77b68606fc1300a06082a8648ce3d04030203470030440220241e81ffd2e5e6153694c3552e8febd71e8935921cb4834143711c76eaeef39502205f80eb10f25ccc398b3ca8a9ada4027f93132077b7abce77465a27f53d33a11d3045022100df9636ce1c6bdd8d1f8884761b0841084ed3d250f842fbcb84b0b61d6b81980702203ec0dcee72dbd44fba04e64f4d0a295b900c25c532018ea322fdcdfa2e6aae18
2018/06/13 21:47:05 key handle: a36ed1dd35d324aaa22c71f29ca04682f15bb4c11d5b43f738928fdc154c93d5cca8cdb98c49d4d917f8e5a4a779d251bd92275802959a0b4f4369c9f6e6b128
2018/06/13 21:47:05 reconnecting to device in 3 seconds...
2018/06/13 21:47:08 authenticating, provide user presence
2018/06/13 21:47:09 counter = 93, signature = 30440220393e1fc2a8f1f1dc1c1ab1fb42ed631c2fe428d9cc3cc01a35145ff97c0f0c9a022014d53ee04c8c1b237f968426856bdd28b3270fca9efcfce97aebd04d3ba292d8
2018/06/13 21:47:09 testing wink in 2s...
```