### PR TITLE
fix #14 getAssertion issue with HyperSecu Mini

### DIFF
--- a/ctap2token/example/main.go
+++ b/ctap2token/example/main.go
@@ -123,9 +123,8 @@ func main() {
 			RPID: "example.com",
 			AllowList: []*ctap2token.CredentialDescriptor{
 				{
-					ID:         mcpAuthData.AttestedCredentialData.CredentialID,
-					Transports: []ctap2token.AuthenticatorTransport{ctap2token.USB},
-					Type:       ctap2token.PublicKey,
+					ID:   mcpAuthData.AttestedCredentialData.CredentialID,
+					Type: ctap2token.PublicKey,
 				},
 			},
 			ClientDataHash: clientDataHash,

--- a/ctap2token/token.go
+++ b/ctap2token/token.go
@@ -629,9 +629,10 @@ const (
 // CredentialDescriptor defines a credential returned by the authenticator,
 // as defined by https://www.w3.org/TR/webauthn/#credential-dictionary
 type CredentialDescriptor struct {
-	ID         []byte                   `cbor:"id"`
-	Type       CredentialType           `cbor:"type"`
-	Transports []AuthenticatorTransport `cbor:"transports"`
+	ID   []byte         `cbor:"id"`
+	Type CredentialType `cbor:"type"`
+	// Don't set transports field when using HyperSecu Mini tokens.
+	Transports []AuthenticatorTransport `cbor:"transports,omitempty"`
 }
 
 // AuthenticatorTransport defines hints as to how clients might communicate with a particular authenticator,


### PR DESCRIPTION
HyperSecu Mini tokens are reporting errors when calling GetAssertion.
It seems these tokens don't support the transports field being set on
the CredentialDescriptor. Luckily it's optionnal so we can safely remove
it.