### PR TITLE
Mention hyperfido pro mini authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Tested with these devices on macOS, Linux, and Windows:
 | Feitian | FIDO K6 | 0x096e | 0x0850 | 11.03 | Yes | Also known as Feitian ePass FIDO Agile 2. |
 | Feitian | MultiPass FIDO | 0x096e | 0x085a | 32.06 | Yes | |
 | Hypersecu | HyperFIDO U2F Security Key | 0x096e | 0x0880 | 10.05 | Yes | Also known as Feitian FIDO K5. |
+| Hypersecu | HyperFIDO Pro Mini Security Key | 0x2ccf | 0x0854 | | Yes | Supports FIDO2 |
 | NEOWAVE | Keydo | 0x1e0d | 0xf1d0 | 1.00 | Yes | |
 | Plug-up | Security Key | 0x2581 | 0xf1d0 | 0.01 | No | |
 | SatoshiLabs | Bitcoin Wallet [TREZOR] | 0x534c | 0x0001 | 1.6.0 | ? | Tested on Linux |

--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ Tested with these devices on macOS, Linux, and Windows:
 On Linux, installation of [udev
 rules](https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules) is
 required.
+
+On Windows, this must be run with Administrator privileges.


### PR DESCRIPTION
@daeMOn63, This mentions the [HyperFIDO Pro Mini authenticator](https://www.hypersecu.com/hyperfido) ([amazon buy link](https://www.amazon.es/gp/product/B0813YWZB2)) in the README and the need to have Administrator privileges when running on Windows.

This device seems to support the wink command, but it only does a single brief led blink, way faster then the normal blinking that the device automatically does when we call `MakeCredential`; so I'm not sure if that classifies as having `Wink` support.

Also, I do not known what to put in the `Version` column. Where do I get the version from?